### PR TITLE
link to new repo location of fuel-docs

### DIFF
--- a/bin/astute
+++ b/bin/astute
@@ -16,7 +16,7 @@
 
 puts <<-EOF 
 CLI interface in Astute no longer supported. Please use new Fuel-CLI. 
-More details you can get by link: https://github.com/Mirantis/fuel-docs/blob/master/pages/user-guide/cli.rst
+More details you can get by link: https://github.com/stackforge/fuel-docs/blob/master/pages/user-guide/cli.rst
 EOF
 
 exit 1


### PR DESCRIPTION
astute links to the old repository location of fuel-docs:

```
[root@fuel ~]# astute 
CLI interface in Astute no longer supported. Please use new Fuel-CLI. 
More details you can get by link: https://github.com/Mirantis/fuel-docs/blob/master/pages/user-guide/cli.rst
```

This pull request corrects this and makes it refer to the stackforge location
